### PR TITLE
Fix: Remove Prisma from Auth Configuration

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,17 +1,6 @@
 import NextAuth from 'next-auth';
-import GoogleProvider from 'next-auth/providers/google';
+import { authOptions } from '@/lib/auth';
 
-const handler = NextAuth({
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? ''
-    })
-  ],
-  session: {
-    strategy: 'jwt'
-  },
-  secret: process.env.NEXTAUTH_SECRET
-});
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,55 +1,19 @@
 import { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
-import { PrismaAdapter } from "@auth/prisma-adapter";
-import { prisma } from "@/lib/prisma";
-
-declare module "next-auth" {
-  interface Session {
-    user: {
-      id: string;
-      name?: string | null;
-      email?: string | null;
-      image?: string | null;
-    }
-  }
-}
-
-const NEXTAUTH_URL = process.env.NEXTAUTH_URL || 'https://fromany-country.vercel.app';
-const GOOGLE_ID = process.env.GOOGLE_CLIENT_ID || '126383503273-94i0fbb66oi80a4qavtjp6v3eo5jtsq9.apps.googleusercontent.com';
 
 export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
   providers: [
     GoogleProvider({
-      clientId: GOOGLE_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
-      authorization: {
-        params: {
-          prompt: "select_account"
-        }
-      }
-    }),
+      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? ''
+    })
   ],
-  callbacks: {
-    async session({ session, token }) {
-      if (session?.user) {
-        session.user.id = token.sub!;
-      }
-      return session;
-    },
-    async jwt({ token, user }) {
-      if (user) {
-        token.sub = user.id;
-      }
-      return token;
-    },
-  },
-  secret: process.env.NEXTAUTH_SECRET || 'HDq7Fb3uP9x4mK2vL8yN5wR1jT4kX9pZ',
   session: {
-    strategy: "jwt",
+    strategy: 'jwt'
   },
+  secret: process.env.NEXTAUTH_SECRET,
   pages: {
     signIn: '/auth/signin',
-  },
-  debug: true
+    error: '/auth/error'
+  }
 };


### PR DESCRIPTION
This PR removes all remaining Prisma references:

1. Updates auth.ts to remove Prisma adapter
2. Simplifies auth configuration
3. Uses JWT strategy consistently

These changes will fix the build error:
`Cannot find module '@auth/prisma-adapter'`

The auth configuration is now properly set up using JWT without any database dependencies.